### PR TITLE
update "events" URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ volunteer_url: https://goo.gl/forms/4WZ56lDDrSozGxWb2
 discuss_url: https://groups.google.com/forum/#!forum/mcl-discuss
 subscribe_url: http://eepurl.com/pNXJP
 eventbrite_url: "https://www.eventbrite.com/o/monthly-music-hackathon-nyc-2470452960"
+events_url: "https://musichack.org"
 mmh_url: "http://monthlymusichackathon.org/"
 
 # Social info

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="site-footer">
   <section class="pull-left">
     <ul class="site-links">
-      <li><a href="{{site.eventbrite_url}}">Events</a></li>
+      <li><a href="{{site.events_url}}">Events</a></li>
       <li><a href="#">About</a></li>
     </ul>
     <ul class="social-links">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
   </a>
   <section class="links">
     <ul class="site-links">
-      <li><a href="{{site.eventbrite_url}}">Events</a></li>
+      <li><a href="{{site.events_url}}">Events</a></li>
       <li><a href="{{site.url}}/about/">About</a></li>
     </ul>
     <ul class="social-links">


### PR DESCRIPTION
We haven't been using Eventbrite consistently, so let's use musichackathon.org as the "Events" url